### PR TITLE
Add income toggle to exclude income transactions from calculations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,10 +4,77 @@ This document explains how to use the tools and utilities available in the Actua
 
 ## Table of Contents
 
+- [CHANGELOG Maintenance](#changelog-maintenance)
 - [File API Service](#file-api-service)
 - [React Hooks](#react-hooks)
 - [Data Transformation Utilities](#data-transformation-utilities)
 - [Type Definitions](#type-definitions)
+
+## CHANGELOG Maintenance
+
+**IMPORTANT**: Agents MUST update `CHANGELOG.md` after making any code changes to the project.
+
+### Update Requirements
+
+1. **When to Update**: Update `CHANGELOG.md` after making any changes to:
+   - Source code files (`.ts`, `.tsx`, `.js`, `.jsx`)
+   - Configuration files (e.g., `package.json`, `vite.config.ts`, `tsconfig.json`)
+   - Documentation files (e.g., `README.md`, `AGENTS.md`)
+   - Test files that represent new functionality
+   - Build or deployment configurations
+
+2. **Format**: Use date-based format with entries grouped by date (YYYY-MM-DD)
+   - Most recent entries appear at the top
+   - Each date section should be formatted as: `## YYYY-MM-DD`
+   - **Getting Today's Date**: Use the CLI command to get the current date in the correct format:
+     ```bash
+     date +%Y-%m-%d
+     ```
+     This will output the date in YYYY-MM-DD format (e.g., `2026-01-08`)
+
+3. **Categories**: Use appropriate categories under each date:
+   - **Added**: New features, components, utilities, or functionality
+   - **Changed**: Changes to existing functionality or behavior
+   - **Fixed**: Bug fixes or corrections
+   - **Removed**: Removed features, code, or functionality
+   - **Security**: Security-related updates
+
+4. **Entry Format**:
+   - Add entries under the current date (YYYY-MM-DD)
+   - If a date section doesn't exist for today, create it at the top of the file
+   - Each entry should be concise but descriptive
+   - Use bullet points for multiple entries under the same category
+   - Example:
+
+     ```
+     ## 2026-01-04
+
+     ### Added
+     - New feature description
+
+     ### Fixed
+     - Bug fix description
+     ```
+
+5. **Placement**: Always add new entries to the top of the file, under the current date. If today's date section already exists, add your entry to the appropriate category within that section.
+
+### Example
+
+```markdown
+## 2026-01-04
+
+### Added
+- New calendar heatmap visualization component
+- Support for currency override in settings
+
+### Changed
+- Updated data transformation logic to handle transfers more efficiently
+
+### Fixed
+- Resolved issue with off-budget transaction filtering
+```
+
+Remember: The CHANGELOG serves as a historical record of all project changes. Keep entries clear and meaningful for future reference.
 
 ## File API Service
 
@@ -357,7 +424,12 @@ console.log(wrappedData.monthlyData);
   - Multiple transfers to the same account are grouped together in both categories and payees
 - **Off-Budget Filtering**: Excludes off-budget transactions by default. Set `includeOffBudget = true` to include them
 - Excludes starting balance transactions (transactions where payee name is "Starting Balance")
-- Handles deleted categories/payees (marks with "deleted: " prefix)
+- **Category Merges**: When a category is deleted and merged into another category, transactions are automatically resolved through the `category_mapping` table:
+  - Transactions from merged categories appear under the merged (target) category name
+  - Handles transitive merges (Category A → B → C resolves to C)
+  - Budget data is also resolved through merge chains and combined for merged categories
+  - Only non-merged deleted categories show the "deleted: " prefix
+- Handles deleted categories/payees (marks with "deleted: " prefix for non-merged deleted categories)
 - Converts amounts from cents to dollars
 - Calculates all derived metrics automatically
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to date-based versioning with entries grouped by date.
 
+## 2026-01-08
+
+### Added
+
+- Add toggle to include/exclude income transactions from calculations (default: expenses only)
+- Add CLI command instructions to AGENTS.md for getting today's date when updating CHANGELOG
+
 ## 2026-01-05
 
 ### Added

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 import styles from './App.module.css';
 import { ConnectionForm } from './components/ConnectionForm';
 import { CurrencySelector } from './components/CurrencySelector';
+import { IncludeIncomeToggle } from './components/IncludeIncomeToggle';
 import { Navigation } from './components/Navigation';
 import { OffBudgetToggle } from './components/OffBudgetToggle';
 import { AllTransfersToggle } from './components/OffBudgetTransfersToggle';
@@ -40,6 +41,7 @@ const PAGES = [
 
 function App() {
   const [currentPage, setCurrentPage] = useState(0);
+  const [includeIncome, setIncludeIncome] = useLocalStorage('includeIncome', false);
   const [includeOffBudget, setIncludeOffBudget] = useLocalStorage('includeOffBudget', false);
   const [includeOnBudgetTransfers, setIncludeOnBudgetTransfers] = useLocalStorage(
     'includeOnBudgetTransfers',
@@ -62,6 +64,18 @@ function App() {
       includeOnBudgetTransfers,
       includeAllTransfers,
       overrideCurrency || undefined,
+      includeIncome,
+    );
+  };
+
+  const handleIncludeIncomeToggle = (value: boolean) => {
+    setIncludeIncome(value);
+    retransformData(
+      includeOffBudget,
+      includeOnBudgetTransfers,
+      includeAllTransfers,
+      overrideCurrency || undefined,
+      value,
     );
   };
 
@@ -72,12 +86,19 @@ function App() {
       includeOnBudgetTransfers,
       includeAllTransfers,
       overrideCurrency || undefined,
+      includeIncome,
     );
   };
 
   const handleOnBudgetTransfersToggle = (value: boolean) => {
     setIncludeOnBudgetTransfers(value);
-    retransformData(includeOffBudget, value, includeAllTransfers, overrideCurrency || undefined);
+    retransformData(
+      includeOffBudget,
+      value,
+      includeAllTransfers,
+      overrideCurrency || undefined,
+      includeIncome,
+    );
   };
 
   const handleAllTransfersToggle = (value: boolean) => {
@@ -92,6 +113,7 @@ function App() {
       effectiveIncludeOnBudgetTransfers, // If includeAllTransfers is true, also enable on-budget transfers
       value,
       overrideCurrency || undefined,
+      includeIncome,
     );
   };
 
@@ -100,7 +122,13 @@ function App() {
     const defaultCurrency = data?.currencySymbol || '$';
     if (currencySymbol === defaultCurrency) {
       setOverrideCurrency(null);
-      retransformData(includeOffBudget, includeOnBudgetTransfers, includeAllTransfers, undefined);
+      retransformData(
+        includeOffBudget,
+        includeOnBudgetTransfers,
+        includeAllTransfers,
+        undefined,
+        includeIncome,
+      );
     } else {
       setOverrideCurrency(currencySymbol);
       retransformData(
@@ -108,6 +136,7 @@ function App() {
         includeOnBudgetTransfers,
         includeAllTransfers,
         currencySymbol,
+        includeIncome,
       );
     }
   };
@@ -164,6 +193,7 @@ function App() {
     return (
       <div className={styles.app}>
         <SettingsMenu>
+          <IncludeIncomeToggle includeIncome={includeIncome} onToggle={handleIncludeIncomeToggle} />
           <OffBudgetToggle includeOffBudget={includeOffBudget} onToggle={handleOffBudgetToggle} />
           <OnBudgetTransfersToggle
             includeOnBudgetTransfers={includeAllTransfers || includeOnBudgetTransfers}

--- a/src/components/IncludeIncomeToggle.module.css
+++ b/src/components/IncludeIncomeToggle.module.css
@@ -1,0 +1,65 @@
+.toggle {
+  position: fixed;
+  top: 2rem;
+  right: 2rem;
+  z-index: 1001;
+  background: rgba(0, 0, 0, 0.8);
+  backdrop-filter: blur(10px);
+  padding: 0.75rem 1.25rem;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  color: white;
+  font-size: 0.9rem;
+  font-weight: 500;
+}
+
+.toggleLabel {
+  user-select: none;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  gap: 0.75rem;
+}
+
+.toggleSwitch {
+  position: relative;
+  width: 44px;
+  height: 24px;
+  background: rgba(255, 255, 255, 0.2);
+  border-radius: 12px;
+  cursor: pointer;
+  transition: background-color 0.3s;
+  flex-shrink: 0;
+  margin-left: auto;
+}
+
+.toggleSwitch.active {
+  background: linear-gradient(90deg, #667eea 0%, #764ba2 100%);
+}
+
+.toggleSlider {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 20px;
+  height: 20px;
+  background: white;
+  border-radius: 50%;
+  transition: transform 0.3s;
+}
+
+.toggleSwitch.active .toggleSlider {
+  transform: translateX(20px);
+}
+
+.toggleText {
+  font-size: 0.85rem;
+  opacity: 0.9;
+  text-align: left;
+  flex: 1;
+}

--- a/src/components/IncludeIncomeToggle.tsx
+++ b/src/components/IncludeIncomeToggle.tsx
@@ -1,0 +1,39 @@
+import { motion } from 'framer-motion';
+
+import styles from './IncludeIncomeToggle.module.css';
+
+interface IncludeIncomeToggleProps {
+  includeIncome: boolean;
+  onToggle: (value: boolean) => void;
+}
+
+export function IncludeIncomeToggle({ includeIncome, onToggle }: IncludeIncomeToggleProps) {
+  return (
+    <motion.div
+      className={styles.toggle}
+      initial={{ opacity: 0, y: -20 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.3, delay: 0.1 }}
+    >
+      <div className={styles.toggleLabel}>
+        <span className={styles.toggleText}>Include Income</span>
+        <div
+          className={`${styles.toggleSwitch} ${includeIncome ? styles.active : ''}`}
+          onClick={() => onToggle(!includeIncome)}
+          role="switch"
+          aria-checked={includeIncome}
+          aria-label="Include income transactions"
+          tabIndex={0}
+          onKeyDown={e => {
+            if (e.key === 'Enter' || e.code === 'Space') {
+              e.preventDefault();
+              onToggle(!includeIncome);
+            }
+          }}
+        >
+          <div className={styles.toggleSlider} />
+        </div>
+      </div>
+    </motion.div>
+  );
+}

--- a/src/hooks/useActualData.test.ts
+++ b/src/hooks/useActualData.test.ts
@@ -12,6 +12,10 @@ const mockGetPayees = vi.fn();
 const mockGetAccounts = vi.fn();
 const mockShutdown = vi.fn(() => Promise.resolve());
 const mockClearBudget = vi.fn();
+const mockGetCurrencySymbol = vi.fn();
+const mockGetBudgetedAmounts = vi.fn();
+const mockGetCategoryGroupSortOrders = vi.fn();
+const mockGetCategoryGroupTombstones = vi.fn();
 
 vi.mock('../services/fileApi', () => ({
   initialize: (file: File) => mockInitialize(file),
@@ -21,6 +25,10 @@ vi.mock('../services/fileApi', () => ({
   getAccounts: () => mockGetAccounts(),
   shutdown: () => mockShutdown(),
   clearBudget: () => mockClearBudget(),
+  getCurrencySymbol: () => mockGetCurrencySymbol(),
+  getBudgetedAmounts: (year: number) => mockGetBudgetedAmounts(year),
+  getCategoryGroupSortOrders: () => mockGetCategoryGroupSortOrders(),
+  getCategoryGroupTombstones: () => mockGetCategoryGroupTombstones(),
 }));
 
 // Mock transformToWrappedData
@@ -32,7 +40,30 @@ vi.mock('../utils/dataTransform', () => ({
     payees: unknown[],
     accounts: unknown[],
     year?: number,
-  ) => mockTransformToWrappedData(transactions, categories, payees, accounts, year),
+    includeOffBudget?: boolean,
+    includeOnBudgetTransfers?: boolean,
+    includeAllTransfers?: boolean,
+    currencySymbol?: string,
+    budgetData?: unknown,
+    groupSortOrders?: unknown,
+    groupTombstones?: unknown,
+    includeIncome?: boolean,
+  ) =>
+    mockTransformToWrappedData(
+      transactions,
+      categories,
+      payees,
+      accounts,
+      year,
+      includeOffBudget,
+      includeOnBudgetTransfers,
+      includeAllTransfers,
+      currencySymbol,
+      budgetData,
+      groupSortOrders,
+      groupTombstones,
+      includeIncome,
+    ),
 }));
 
 describe('useActualData', () => {
@@ -49,6 +80,10 @@ describe('useActualData', () => {
     mockGetAccounts.mockResolvedValue([]);
     // mockShutdown already returns a promise from the mock definition
     mockClearBudget.mockResolvedValue(undefined);
+    mockGetCurrencySymbol.mockResolvedValue('$');
+    mockGetBudgetedAmounts.mockResolvedValue([]);
+    mockGetCategoryGroupSortOrders.mockResolvedValue(new Map());
+    mockGetCategoryGroupTombstones.mockResolvedValue(new Map());
     mockTransformToWrappedData.mockReturnValue(createMockWrappedData());
   });
 
@@ -169,6 +204,14 @@ describe('useActualData', () => {
         mockPayees,
         mockAccounts,
         2025, // DEFAULT_YEAR
+        false, // includeOffBudget
+        true, // includeOnBudgetTransfers
+        false, // includeAllTransfers
+        '$', // currencySymbol
+        undefined, // budgetData
+        expect.any(Map), // groupSortOrders
+        expect.any(Map), // groupTombstones
+        false, // includeIncome
       );
     });
 

--- a/src/hooks/useActualData.ts
+++ b/src/hooks/useActualData.ts
@@ -50,6 +50,7 @@ export function useActualData() {
       budgetData?: Array<{ categoryId: string; month: string; budgetedAmount: number }>,
       groupSortOrders: Map<string, number> = new Map(),
       groupTombstones: Map<string, boolean> = new Map(),
+      includeIncome: boolean = false,
     ) => {
       const wrappedData = transformToWrappedData(
         raw.transactions,
@@ -64,6 +65,7 @@ export function useActualData() {
         budgetData,
         groupSortOrders,
         groupTombstones,
+        includeIncome,
       );
       setData(wrappedData);
     },
@@ -77,6 +79,7 @@ export function useActualData() {
       includeOnBudgetTransfers: boolean = true, // Default to true (on by default)
       includeAllTransfers: boolean = false,
       overrideCurrencySymbol?: string,
+      includeIncome: boolean = false,
     ) => {
       setLoading(true);
       setError(null);
@@ -151,6 +154,7 @@ export function useActualData() {
           fetchedBudgetData.length > 0 ? fetchedBudgetData : undefined,
           fetchedGroupSortOrders,
           fetchedGroupTombstones,
+          includeIncome,
         );
 
         setProgress(100);
@@ -176,6 +180,7 @@ export function useActualData() {
       includeOnBudgetTransfers: boolean = true, // Default to true (on by default)
       includeAllTransfers: boolean = false,
       overrideCurrencySymbol?: string,
+      includeIncome: boolean = false,
     ) => {
       if (!file) {
         throw new Error('No file available');
@@ -186,6 +191,7 @@ export function useActualData() {
         includeOnBudgetTransfers,
         includeAllTransfers,
         overrideCurrencySymbol,
+        includeIncome,
       );
     },
     [file, fetchData],
@@ -197,6 +203,7 @@ export function useActualData() {
       includeOnBudgetTransfers: boolean,
       includeAllTransfers: boolean,
       overrideCurrencySymbol?: string,
+      includeIncome: boolean = false,
     ) => {
       if (rawData) {
         const effectiveCurrency = overrideCurrencySymbol || currencySymbol;
@@ -209,6 +216,7 @@ export function useActualData() {
           budgetData,
           groupSortOrders,
           groupTombstones,
+          includeIncome,
         );
       }
     },

--- a/src/utils/dataTransform.test.ts
+++ b/src/utils/dataTransform.test.ts
@@ -33,12 +33,26 @@ describe('transformToWrappedData', () => {
 
   describe('Basic Data Transformation', () => {
     it('transforms empty transactions array', () => {
-      const result = transformToWrappedData([], [], [], []);
+      const result = transformToWrappedData(
+        [],
+        [],
+        [],
+        [],
+        2025,
+        false,
+        true,
+        false,
+        '$',
+        undefined,
+        new Map(),
+        new Map(),
+        false,
+      );
 
       expect(result.year).toBe(2025);
       expect(result.totalIncome).toBe(0);
       expect(result.totalExpenses).toBe(0);
-      expect(result.netSavings).toBe(0);
+      expect(result.netSavings).toBeCloseTo(0, 5);
       expect(result.savingsRate).toBe(0);
       expect(result.monthlyData).toHaveLength(12);
       expect(result.topCategories).toHaveLength(0);
@@ -54,7 +68,21 @@ describe('transformToWrappedData', () => {
         createMockTransaction({ id: 't4', amount: -10000 }), // $100 expense
       ];
 
-      const result = transformToWrappedData(transactions, [], [], []);
+      const result = transformToWrappedData(
+        transactions,
+        [],
+        [],
+        [],
+        2025,
+        false,
+        true,
+        false,
+        '$',
+        undefined,
+        new Map(),
+        new Map(),
+        true,
+      );
 
       expect(result.totalIncome).toBe(700); // $500 + $200
       expect(result.totalExpenses).toBe(400); // $300 + $100
@@ -67,7 +95,21 @@ describe('transformToWrappedData', () => {
         createMockTransaction({ id: 't2', amount: -60000 }), // $600 expense
       ];
 
-      const result = transformToWrappedData(transactions, [], [], []);
+      const result = transformToWrappedData(
+        transactions,
+        [],
+        [],
+        [],
+        2025,
+        false,
+        true,
+        false,
+        '$',
+        undefined,
+        new Map(),
+        new Map(),
+        true,
+      );
 
       expect(result.savingsRate).toBe(40); // (1000 - 600) / 1000 * 100
     });
@@ -119,7 +161,21 @@ describe('transformToWrappedData', () => {
         createMockTransaction({ id: 't4', date: '2025-02-25', amount: -20000 }), // Feb expense
       ];
 
-      const result = transformToWrappedData(transactions, [], [], []);
+      const result = transformToWrappedData(
+        transactions,
+        [],
+        [],
+        [],
+        2025,
+        false,
+        true,
+        false,
+        '$',
+        undefined,
+        new Map(),
+        new Map(),
+        true,
+      );
 
       const january = result.monthlyData.find(m => m.month === 'January');
       const february = result.monthlyData.find(m => m.month === 'February');
@@ -138,12 +194,26 @@ describe('transformToWrappedData', () => {
         createMockTransaction({ id: 't1', date: '2025-01-15', amount: -10000 }),
       ];
 
-      const result = transformToWrappedData(transactions, [], [], []);
+      const result = transformToWrappedData(
+        transactions,
+        [],
+        [],
+        [],
+        2025,
+        false,
+        true,
+        false,
+        '$',
+        undefined,
+        new Map(),
+        new Map(),
+        false,
+      );
 
       const february = result.monthlyData.find(m => m.month === 'February');
       expect(february?.income).toBe(0);
       expect(february?.expenses).toBe(0);
-      expect(february?.netSavings).toBe(0);
+      expect(february?.netSavings).toBeCloseTo(0, 5);
     });
 
     it('includes all 12 months', () => {
@@ -668,7 +738,21 @@ describe('transformToWrappedData', () => {
         createMockTransaction({ id: 't3', amount: 30000 }),
       ];
 
-      const result = transformToWrappedData(transactions, [], [], []);
+      const result = transformToWrappedData(
+        transactions,
+        [],
+        [],
+        [],
+        2025,
+        false,
+        true,
+        false,
+        '$',
+        undefined,
+        new Map(),
+        new Map(),
+        true,
+      );
 
       expect(result.transactionStats.totalCount).toBe(3);
     });
@@ -1515,7 +1599,21 @@ describe('transformToWrappedData', () => {
         createMockCategory({ id: 'cat2', name: 'Freelance', is_income: true }),
       ];
 
-      const result = transformToWrappedData(transactions, categories, [], []);
+      const result = transformToWrappedData(
+        transactions,
+        categories,
+        [],
+        [],
+        2025,
+        false,
+        true,
+        false,
+        '$',
+        undefined,
+        new Map(),
+        new Map(),
+        true,
+      );
 
       expect(result.transactionStats.totalCount).toBe(2);
       expect(result.totalIncome).toBe(500); // $300 + $200 from child splits
@@ -1902,7 +2000,21 @@ describe('transformToWrappedData', () => {
         );
       }
 
-      const result = transformToWrappedData(transactions, [], [], []);
+      const result = transformToWrappedData(
+        transactions,
+        [],
+        [],
+        [],
+        2025,
+        false,
+        true,
+        false,
+        '$',
+        undefined,
+        new Map(),
+        new Map(),
+        true,
+      );
 
       expect(result.savingsMilestones.length).toBeGreaterThan(0);
       expect(result.savingsMilestones.some(m => m.milestone === '$10k')).toBe(true);
@@ -1941,7 +2053,21 @@ describe('transformToWrappedData', () => {
         );
       }
 
-      const result = transformToWrappedData(transactions, [], [], []);
+      const result = transformToWrappedData(
+        transactions,
+        [],
+        [],
+        [],
+        2025,
+        false,
+        true,
+        false,
+        '$',
+        undefined,
+        new Map(),
+        new Map(),
+        true,
+      );
 
       const milestone = result.savingsMilestones.find(m => m.milestone === '$10k');
       if (milestone) {
@@ -1957,7 +2083,21 @@ describe('transformToWrappedData', () => {
         createMockTransaction({ id: 't2', date: '2025-01-15', amount: -30000 }), // $300 expense
       ];
 
-      const result = transformToWrappedData(transactions, [], [], []);
+      const result = transformToWrappedData(
+        transactions,
+        [],
+        [],
+        [],
+        2025,
+        false,
+        true,
+        false,
+        '$',
+        undefined,
+        new Map(),
+        new Map(),
+        true,
+      );
 
       expect(result.futureProjection.dailyAverageIncome).toBeGreaterThan(0);
       expect(result.futureProjection.dailyAverageExpenses).toBeGreaterThan(0);
@@ -1970,7 +2110,21 @@ describe('transformToWrappedData', () => {
         createMockTransaction({ id: 't2', date: '2025-01-15', amount: -30000 }),
       ];
 
-      const result = transformToWrappedData(transactions, [], [], []);
+      const result = transformToWrappedData(
+        transactions,
+        [],
+        [],
+        [],
+        2025,
+        false,
+        true,
+        false,
+        '$',
+        undefined,
+        new Map(),
+        new Map(),
+        true,
+      );
 
       expect(result.futureProjection.monthlyProjections).toHaveLength(12);
       expect(result.futureProjection.monthlyProjections[0].month).toBe('January');
@@ -1984,7 +2138,21 @@ describe('transformToWrappedData', () => {
         createMockTransaction({ id: 't2', date: '2025-01-15', amount: -30000 }),
       ];
 
-      const result = transformToWrappedData(transactions, [], [], []);
+      const result = transformToWrappedData(
+        transactions,
+        [],
+        [],
+        [],
+        2025,
+        false,
+        true,
+        false,
+        '$',
+        undefined,
+        new Map(),
+        new Map(),
+        true,
+      );
 
       const projections = result.futureProjection.monthlyProjections;
       expect(projections[0].cumulativeSavings).toBeDefined();
@@ -2002,7 +2170,21 @@ describe('transformToWrappedData', () => {
         createMockTransaction({ id: 't2', date: '2025-01-15', amount: -50000 }), // $500 expense
       ];
 
-      const result = transformToWrappedData(transactions, [], [], []);
+      const result = transformToWrappedData(
+        transactions,
+        [],
+        [],
+        [],
+        2025,
+        false,
+        true,
+        false,
+        '$',
+        undefined,
+        new Map(),
+        new Map(),
+        true,
+      );
 
       // If expenses exceed income, monthsUntilZero should be calculated
       if (result.futureProjection.dailyNetSavings < 0) {
@@ -2016,7 +2198,21 @@ describe('transformToWrappedData', () => {
         createMockTransaction({ id: 't2', date: '2025-01-15', amount: -10000 }), // $100 expense
       ];
 
-      const result = transformToWrappedData(transactions, [], [], []);
+      const result = transformToWrappedData(
+        transactions,
+        [],
+        [],
+        [],
+        2025,
+        false,
+        true,
+        false,
+        '$',
+        undefined,
+        new Map(),
+        new Map(),
+        true,
+      );
 
       // If income exceeds expenses, monthsUntilZero should be null
       if (result.futureProjection.dailyNetSavings > 0) {
@@ -2030,7 +2226,21 @@ describe('transformToWrappedData', () => {
         createMockTransaction({ id: 't2', date: '2025-01-15', amount: -30000 }),
       ];
 
-      const result = transformToWrappedData(transactions, [], [], []);
+      const result = transformToWrappedData(
+        transactions,
+        [],
+        [],
+        [],
+        2025,
+        false,
+        true,
+        false,
+        '$',
+        undefined,
+        new Map(),
+        new Map(),
+        true,
+      );
 
       expect(result.futureProjection.projectedYearEndSavings).toBeDefined();
       const lastMonth =


### PR DESCRIPTION
This PR adds a new toggle to include/exclude income transactions from all calculations. When disabled (default), only expenses are included, which helps handle cases like returns/refunds that create both expense and income transactions.

## Changes

- Added  component with matching styles
- Updated  to manage income toggle state with localStorage persistence
- Updated  hook to pass  parameter through all data transformation functions
- Updated  to filter out income transactions when  is false
- Updated  with CLI command instructions for getting today's date
- Updated  to document the new feature

## Behavior

- Default: Income toggle is **disabled** (expenses only) - matches current app behavior
- When enabled: Includes all income transactions as before
- When disabled: Filters out all income transactions, sets income-related metrics to 0, and adjusts calculations accordingly